### PR TITLE
Refactor into real package

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (c) 2012 - 2022, Anaconda, Inc., and Bokeh Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+Neither the name of Anaconda nor the names of any contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-git-versioning", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bokeh_fastapi"
+dynamic = ["version"]
+description = "A web application using Bokeh and FastAPI"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [
+    { name = "Philipp Rudiger", email = "prudiger@anaconda.com" }
+]
+license = {file = "LICENSE.txt"}
+dependencies = [
+    "fastapi>=0.68.0",
+    "bokeh>=2.3.3",
+    "uvicorn>=0.15.0"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/bokeh_fastapi/__init__.py
+++ b/src/bokeh_fastapi/__init__.py
@@ -1,0 +1,1 @@
+from .application import BokehFastAPI

--- a/src/bokeh_fastapi/application.py
+++ b/src/bokeh_fastapi/application.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import logging
+
+from typing import (
+    TYPE_CHECKING, Any, Mapping, Sequence,
+)
+from urllib.parse import urljoin
+
+from bokeh.application import Application
+from bokeh.application.handlers.document_lifecycle import DocumentLifecycleHandler
+from bokeh.application.handlers.function import FunctionHandler
+from bokeh.embed.bundle import extension_dirs
+from bokeh.resources import Resources
+from bokeh.server.connection import ServerConnection
+from bokeh.server.contexts import ApplicationContext
+from bokeh.server.session import ServerSession
+from bokeh.server.views.static_handler import StaticHandler
+from bokeh.settings import settings
+from fastapi import APIRouter, FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from .handler import DocHandler, WSHandler
+
+if TYPE_CHECKING:
+    from ..application.handlers.function import ModifyDoc
+
+    from bokeh.protocol import Protocol
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CHECK_UNUSED_MS                  = 17000
+DEFAULT_KEEP_ALIVE_MS                    = 37000  # heroku, nginx default to 60s timeout, so use less than that
+DEFAULT_UNUSED_LIFETIME_MS               = 15000
+DEFAULT_SESSION_TOKEN_EXPIRATION         = 300
+
+__all__ = (
+    'BokehFastAPI',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class BokehFastAPI:
+    """
+        applications (dict[str,Application] or Application) :
+            A map from paths to ``Application`` instances.
+
+            If the value is a single Application, then the following mapping
+            is generated:
+
+            .. code-block:: python
+
+                applications = {{ '/' : applications }}
+
+            When a connection comes in to a given path, the associate
+            Application is used to generate a new document for the session.
+
+        prefix (str, optional) :
+            A URL prefix to use for all Bokeh server paths. (default: None)
+
+        secret_key (str, optional) :
+            A secret key for signing session IDs.
+
+            Defaults to the current value of the environment variable
+            ``BOKEH_SECRET_KEY``
+
+        sign_sessions (bool, optional) :
+            Whether to cryptographically sign session IDs
+
+            Defaults to the current value of the environment variable
+            ``BOKEH_SIGN_SESSIONS``. If ``True``, then ``secret_key`` must
+            also be provided (either via environment setting or passed as
+            a parameter value)
+
+        keep_alive_milliseconds (int, optional) :
+            Number of milliseconds between keep-alive pings
+            (default: {DEFAULT_KEEP_ALIVE_MS})
+
+            Pings normally required to keep the websocket open. Set to 0 to
+            disable pings.
+
+        check_unused_sessions_milliseconds (int, optional) :
+            Number of milliseconds between checking for unused sessions
+            (default: {DEFAULT_CHECK_UNUSED_MS})
+
+        unused_session_lifetime_milliseconds (int, optional) :
+            Number of milliseconds for unused session lifetime
+            (default: {DEFAULT_UNUSED_LIFETIME_MS})
+
+        include_headers (list, optional) :
+            List of request headers to include in session context
+            (by default all headers are included)
+
+        exclude_headers (list, optional) :
+            List of request headers to exclude in session context
+            (by default all headers are included)
+
+        include_cookies (list, optional) :
+            List of cookies to include in session context
+            (by default all cookies are included)
+
+        exclude_cookies (list, optional) :
+            List of cookies to exclude in session context
+            (by default all cookies are included)
+
+        session_token_expiration (int, optional) :
+            Duration in seconds that a new session token is valid
+            for session creation. After the expiry time has elapsed,
+            the token will not be able create a new session
+            (default: {DEFAULT_SESSION_TOKEN_EXPIRATION})
+    """
+
+    def __init__(
+        self,
+        applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+        server: FastAPI | None = None,
+        prefix: str | None = None,
+        extra_websocket_origins: Sequence[str] | None = None,
+        secret_key: bytes | None = settings.secret_key_bytes(),
+        sign_sessions: bool = settings.sign_sessions(),
+        generate_session_ids: bool = True,
+        keep_alive_milliseconds: int = DEFAULT_KEEP_ALIVE_MS,
+        check_unused_sessions_milliseconds: int = DEFAULT_CHECK_UNUSED_MS,
+        unused_session_lifetime_milliseconds: int = DEFAULT_UNUSED_LIFETIME_MS,
+        index: str | None = None,
+        xsrf_cookies: bool = False,
+        include_headers: list[str] | None = None,
+        include_cookies: list[str] | None = None,
+        exclude_headers: list[str] | None = None,
+        exclude_cookies: list[str] | None = None,
+        session_token_expiration: int = DEFAULT_SESSION_TOKEN_EXPIRATION,
+        **kwargs: Any
+    ):
+        if callable(applications):
+            applications = Application(FunctionHandler(applications))
+
+        if isinstance(applications, Application):
+            applications = {'/' : applications}
+        else:
+            applications = dict(applications)
+        
+        for url, app in applications.items():
+            if callable(app):
+                applications[url] = app = Application(FunctionHandler(app))
+            if all(not isinstance(handler, DocumentLifecycleHandler) for handler in app._handlers):
+                app.add(DocumentLifecycleHandler())
+
+        # Wrap applications in ApplicationContext
+        self._applications = {}
+        for url, app in applications.items():
+            self._applications[url] = ApplicationContext(app, url=url)
+
+        if server is None:
+            server = FastAPI()
+        self.server = server
+
+        if prefix is None:
+            prefix = ""
+        prefix = prefix.strip("/")
+        if prefix:
+            prefix = "/" + prefix
+
+        self._prefix = prefix
+
+        if keep_alive_milliseconds < 0:
+            # 0 means "disable"
+            raise ValueError("keep_alive_milliseconds must be >= 0")
+        else:
+            if keep_alive_milliseconds == 0:
+                log.info("Keep-alive ping disabled")
+            elif keep_alive_milliseconds != DEFAULT_KEEP_ALIVE_MS:
+                log.info("Keep-alive ping configured every %d milliseconds", keep_alive_milliseconds)
+        self._keep_alive_milliseconds = keep_alive_milliseconds
+
+        if check_unused_sessions_milliseconds <= 0:
+            raise ValueError("check_unused_sessions_milliseconds must be > 0")
+        elif check_unused_sessions_milliseconds != DEFAULT_CHECK_UNUSED_MS:
+            log.info("Check for unused sessions every %d milliseconds", check_unused_sessions_milliseconds)
+        self._check_unused_sessions_milliseconds = check_unused_sessions_milliseconds
+
+        if unused_session_lifetime_milliseconds <= 0:
+            raise ValueError("unused_session_lifetime_milliseconds must be > 0")
+        elif unused_session_lifetime_milliseconds != DEFAULT_UNUSED_LIFETIME_MS:
+            log.info("Unused sessions last for %d milliseconds", unused_session_lifetime_milliseconds)
+        self._unused_session_lifetime_milliseconds = unused_session_lifetime_milliseconds
+
+        if exclude_cookies and include_cookies:
+            raise ValueError("Declare either an include or an exclude list for the cookies, not both.")
+        self._exclude_cookies = exclude_cookies
+        self._include_cookies = include_cookies
+
+        if exclude_headers and include_headers:
+            raise ValueError("Declare either an include or an exclude list for the headers, not both.")
+        self._exclude_headers = exclude_headers
+        self._include_headers = include_headers
+
+        if extra_websocket_origins is None:
+            self._websocket_origins = set()
+        else:
+            self._websocket_origins = set(extra_websocket_origins)
+
+        self._secret_key = secret_key
+        self._sign_sessions = sign_sessions
+
+        self._clients = set()
+        self.router = APIRouter()
+
+        for route, ctx in self._applications.items():
+            doc_handler = DocHandler(self, application_context=ctx)
+            self.router.add_api_route(f'{route}', doc_handler.get, methods=['GET'])
+            ws_handler = WSHandler(self, application_context=ctx)
+            self.router.add_websocket_route(f'{route}ws', ws_handler.ws_connect)
+        server.include_router(self.router)
+
+        # Mount static file handlers
+        for ext_name, ext_path in extension_dirs.items():
+            server.mount(f"/static/extensions/{ext_name}", StaticFiles(directory=ext_path), name=ext_name)
+        server.mount("/static", StaticFiles(directory=settings.bokehjsdir()), name="static")
+
+    def new_connection(
+        self, protocol: Protocol, socket: WSHandler,
+        application_context: ApplicationContext, session: ServerSession
+    ) -> ServerConnection:
+        connection = ServerConnection(protocol, socket, application_context, session)
+        self._clients.add(connection)
+        return connection
+
+    def client_lost(self, connection: ServerConnection) -> None:
+        self._clients.discard(connection)
+        connection.detach_session()
+
+    @property
+    def websocket_origins(self) -> set[str]:
+        ''' A list of websocket origins permitted to connect to this server.
+
+        '''
+        return self._websocket_origins
+
+    @property
+    def secret_key(self) -> bytes | None:
+        ''' A secret key for this Bokeh Server Tornado Application to use when
+        signing session IDs, if configured.
+
+        '''
+        return self._secret_key
+
+    @property
+    def include_cookies(self) -> list[str] | None:
+        ''' A list of request cookies to make available in the session
+        context.
+
+        '''
+        return self._include_cookies
+
+    @property
+    def include_headers(self) -> list[str] | None:
+        ''' A list of request headers to make available in the session
+        context.
+
+        '''
+        return self._include_headers
+
+    @property
+    def exclude_cookies(self) -> list[str] | None:
+        ''' A list of request cookies to exclude in the session context.
+
+        '''
+        return self._exclude_cookies
+
+    @property
+    def exclude_headers(self) -> list[str] | None:
+        ''' A list of request headers to exclude in the session context.
+
+        '''
+        return self._exclude_headers
+
+    @property
+    def sign_sessions(self) -> bool:
+        ''' Whether this Bokeh Server Tornado Application has been configured
+        to cryptographically sign session IDs
+
+        If ``True``, then ``secret_key`` must also have been configured.
+        '''
+        return self._sign_sessions
+
+    @property
+    def generate_session_ids(self) -> bool:
+        ''' Whether this Bokeh Server Tornado Application has been configured
+        to automatically generate session IDs.
+
+        '''
+        return self._generate_session_ids
+
+    @property
+    def session_token_expiration(self) -> int:
+        ''' Duration in seconds that a new session token is valid for
+        session creation.
+
+        After the expiry time has elapsed, the token will not be able
+        create a new session.
+        '''
+        return self._session_token_expiration
+
+    def resources(self, absolute_url: str | None = None) -> Resources:
+        mode = settings.resources(default="server")
+        if mode == "server":
+            root_url = urljoin(absolute_url, self._prefix) if absolute_url else self._prefix
+            return Resources(mode="server", root_url=root_url, path_versioner=StaticHandler.append_version)
+        return Resources(mode=mode)

--- a/src/bokeh_fastapi/handler.py
+++ b/src/bokeh_fastapi/handler.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import calendar
+import datetime as dt
+import json
+import logging
+
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
+
+from fastapi import (
+    Request, WebSocket, WebSocketDisconnect
+)
+from fastapi.responses import HTMLResponse
+
+from panel.io.server import server_html_page_for_session
+from bokeh.protocol import Protocol
+from bokeh.protocol.exceptions import MessageError, ProtocolError, ValidationError
+from bokeh.protocol.message import Message
+from bokeh.protocol.receiver import Receiver
+from bokeh.server.contexts import ApplicationContext
+from bokeh.server.protocol_handler import ProtocolHandler
+from bokeh.server.session import ServerSession
+from bokeh.server.util import check_allowlist
+from bokeh.settings import settings
+from bokeh.util.token import (
+    check_token_signature,
+    generate_jwt_token,
+    generate_session_id,
+    get_session_id,
+    get_token_payload,
+)
+from tornado.ioloop import IOLoop
+
+if TYPE_CHECKING:
+    from .application import BokehFastAPI
+
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+log = logging.getLogger(__name__)
+
+__all__ = (
+    'DocHandler',
+    'WSHandler',
+)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+class SessionHandler:
+
+    def __init__(self, application: BokehFastAPI, application_context: ApplicationContext):
+        self.application = application
+        self.application_context = application_context
+        if application_context.io_loop is None:
+            application_context._loop = IOLoop.current()
+
+    async def get_session(
+        self,
+        request: Request,
+        session_id: str | None,
+        token: str | None = None
+    ) -> ServerSession:
+        app = self.application
+        if session_id is None:
+            session_id = generate_session_id(
+                secret_key=app.secret_key,
+                signed=app.sign_sessions
+            )
+    
+        # Patch the request
+        request.protocol = 'http'
+        request.host = request.client.host
+        request.uri = request.url.path
+
+        if app.include_headers is None:
+            excluded_headers = (app.exclude_headers or [])
+            allowed_headers = [header for header in request.headers
+                               if header not in excluded_headers]
+        else:
+            allowed_headers = app.include_headers
+        headers = {k: v for k, v in request.headers.items()
+                   if k in allowed_headers}
+
+        if app.include_cookies is None:
+            excluded_cookies = (app.exclude_cookies or [])
+            allowed_cookies = [cookie for cookie in request.cookies
+                               if cookie not in excluded_cookies]
+        else:
+            allowed_cookies = app.include_cookies
+        cookies = {k: v for k, v in request.cookies.items()
+                   if k in allowed_cookies}
+
+        if cookies and 'Cookie' in headers and 'Cookie' not in (app.include_headers or []):
+            # Do not include Cookie header since cookies can be restored from cookies dict
+            del headers['Cookie']
+
+        arguments = {} if request.query_params is None else request.query_params._dict
+        payload = {'headers': headers, 'cookies': cookies, 'arguments': arguments}
+        payload.update(self.application_context.application.process_request(request))
+        token = generate_jwt_token(
+            session_id,
+            secret_key=app.secret_key,
+            signed=app.sign_sessions,
+            expiration=300,
+            extra_payload=payload
+        )
+        session = await self.application_context.create_session_if_needed(
+            session_id, request, token
+        )
+        return session
+
+
+class DocHandler(SessionHandler):
+
+    async def get(self, request: Request, bokeh_session_id: str | None = None) -> HTMLResponse:
+        session = await self.get_session(request, bokeh_session_id)
+        page = server_html_page_for_session(
+            session,
+            resources=self.application.resources(),
+            title=session.document.title,
+            template=session.document.template,
+            template_variables=session.document.template_variables
+        )
+        return HTMLResponse(page)
+
+
+class WSHandler(SessionHandler):
+    
+    def __init__(self, application: BokehFastAPI, application_context: ApplicationContext):
+        super().__init__(application, application_context)
+        self.receiver = None
+        self.handler = None
+        self.connection = None
+        self._socket = None
+
+    def check_origin(self, origin: str) -> bool:
+        ''' Implement a check_origin policy for Tornado to call.
+
+        The supplied origin will be compared to the Bokeh server allowlist. If the
+        origin is not allow, an error will be logged and ``False`` will be returned.
+
+        Args:
+            origin (str) :
+                The URL of the connection origin
+
+        Returns:
+            bool, True if the connection is allowed, False otherwise
+
+        '''
+        parsed_origin = urlparse(origin)
+        origin_host = parsed_origin.netloc.lower()
+
+        allowed_hosts = self.application.websocket_origins
+        if settings.allowed_ws_origin():
+            allowed_hosts = set(settings.allowed_ws_origin())
+
+        allowed = check_allowlist(origin_host, allowed_hosts)
+        if allowed:
+            return True
+        else:
+            log.error("Refusing websocket connection from Origin '%s'; \
+                      use --allow-websocket-origin=%s or set BOKEH_ALLOW_WS_ORIGIN=%s to permit this; currently we allow origins %r",
+                      origin, origin_host, origin_host, allowed_hosts)
+            return False
+
+    async def ws_connect(self, websocket):
+        if len(websocket.scope['subprotocols']) == 2:
+            subprotocol, token = websocket.scope['subprotocols']
+        else:
+            subprotocol = None
+        if subprotocol != 'bokeh' or token is None:
+            websocket.close()
+            raise RuntimeError("Subprotocol header is not 'bokeh' or token not provided")
+
+        now = calendar.timegm(dt.datetime.now(tz=dt.timezone.utc).timetuple())
+        payload = get_token_payload(token)
+        if 'session_expiry' not in payload:
+            websocket.close()
+            raise RuntimeError("Session expiry has not been provided")
+        elif now >= payload['session_expiry']:
+            websocket.close()
+            raise RuntimeError("Token is expired.")
+        elif not check_token_signature(
+            token,
+            signed=self.application.sign_sessions,
+            secret_key=self.application.secret_key
+        ):
+            session_id = get_session_id(token)
+            log.error("Token for session %r had invalid signature", session_id)
+            raise ProtocolError("Invalid token signature")
+
+        self._socket = websocket
+        await websocket.accept('bokeh')
+
+        try:
+            await self._async_open(websocket, token)
+        except Exception as e:
+            # this isn't really an error (unless we have a
+            # bug), it just means a client disconnected
+            # immediately, most likely.
+            print(e)
+            log.debug("Failed to fully open connection %r", e)
+            return
+
+        try:
+            await self._receive_loop()
+        except Exception:
+            pass
+
+    async def _receive(self, fragment: str | bytes) -> Message[Any] | None:
+        # Receive fragments until a complete message is assembled
+        try:
+            message = await self.receiver.consume(fragment)
+            return message
+        except (MessageError, ProtocolError, ValidationError) as e:
+            self._protocol_error(str(e))
+            return None
+
+    async def _handle(self, message: Message[Any]) -> Any | None:
+        # Handle the message, possibly resulting in work to do
+        try:
+            work = await self.handler.handle(message, self.connection)
+            return work
+        except (MessageError, ProtocolError, ValidationError) as e: # TODO (other exceptions?)
+            self._internal_error(str(e))
+            return None
+
+    async def _schedule(self, work: Any) -> None:
+        if isinstance(work, Message):
+            await self.send_message(cast(Message[Any], work))
+        else:
+            self._internal_error(f"expected a Message not {work!r}")
+
+        return None
+
+    async def _receive_loop(self):
+        while True:
+            try:
+                ws_msg = await self._socket.receive()
+            except WebSocketDisconnect as e:
+                log.info('WebSocket connection closed: code=%s, reason=%r', e.code, e.reason)
+                self.application.client_lost(self.connection)
+
+            if 'text' in ws_msg:
+                fragment = ws_msg['text']
+            elif 'bytes' in ws_msg:
+                fragment = ws_msg['bytes']
+            else:
+                continue
+
+            try:
+                message = await self._receive(fragment)
+            except Exception as e:
+                # If you go look at self._receive, it's catching the
+                # expected error types... here we have something weird.
+                log.error("Unhandled exception receiving a message: %r: %r", e, fragment, exc_info=True)
+                self._internal_error("server failed to parse a message")
+                message = None
+
+            if not message:
+                continue
+            try:
+                work = await self._handle(message)
+                if work:
+                    await self.send_message(work)
+            except Exception as e:
+                log.error("Handler or its work threw an exception: %r: %r", e, message, exc_info=True)
+                self._internal_error("server failed to handle a message")
+
+    def _internal_error(self, message: str) -> None:
+        log.error("Bokeh Server internal error: %s, closing connection", message)
+        self._socket.close(10000, message)
+        self.on_close(10000, message)
+
+    def _protocol_error(self, message: str) -> None:
+        log.error("Bokeh Server protocol error: %s, closing connection", message)
+        self._socket.close(10001, message)
+
+    async def _async_open(self, socket: WebSocket, token: str):
+        session_id = get_session_id(token)
+        await self.application_context.create_session_if_needed(session_id, socket.scope, token)
+        session = self.application_context.get_session(session_id)
+
+        protocol = Protocol()
+        log.debug("Receiver created for %r", protocol)
+        self.receiver = Receiver(protocol)
+
+        self.handler = ProtocolHandler()
+        log.debug("ProtocolHandler created for %r", protocol)
+
+        self.connection = self.application.new_connection(
+            protocol, self, self.application_context, session
+        )
+
+        msg = self.connection.protocol.create('ACK')
+        await self.send_message(msg)
+
+    def on_close(self, code: int, reason: str) -> None:
+        ''' Clean up when the connection is closed.
+
+        '''
+        log.info('WebSocket connection closed: code=%s, reason=%r', code, reason)
+        if self.connection is not None:
+            self.application.client_lost(self.connection)
+
+    async def send_text(self, text):
+        await self._socket.send_text(text)
+        
+    async def send_bytes(self, bytestream):
+        await self._socket.send_bytestream(bytestream)
+
+    async def send_message(self, message: Message) -> int:
+        sent = 0
+        try:
+            await self._socket.send_text(message.header_json)
+            sent += len(message.header_json)
+
+            await self._socket.send_text(message.metadata_json)
+            sent += len(message.metadata_json)
+
+            await self._socket.send_text(message.content_json)
+            sent += len(message.content_json)
+
+            for header, payload in message._buffers:
+                await self._socket.send_text(json.dumps(header))
+                await self._socket.send_bytes(payload)
+                sent += len(header) + len(payload)
+        except WebSocketDisconnect as e:
+            self.on_close(e.code, e.reason)
+        return sent

--- a/test.py
+++ b/test.py
@@ -1,225 +1,37 @@
-from __future__ import annotations
-
-import calendar
-import datetime as dt
-import pathlib
-
 from functools import partial
-from types import FunctionType, MethodType
-from urllib.parse import urljoin
 
-from fastapi import APIRouter, FastAPI, Request, WebSocket
-from fastapi.responses import HTMLResponse
-from fastapi.staticfiles import StaticFiles
-
-from panel import panel as as_panel
-from panel.io.server import server_html_page_for_session
-from panel.io.state import set_curdoc
+import panel as pn
 
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
-from bokeh.command.util import build_single_handler_application
-from bokeh.document import Document
-from bokeh.embed.bundle import extension_dirs
-from bokeh.protocol import Protocol
-from bokeh.protocol.message import Message
-from bokeh.protocol.receiver import Receiver
-from bokeh.resources import Resources
-from bokeh.server.connection import ServerConnection
-from bokeh.server.contexts import ApplicationContext
-from bokeh.server.protocol_handler import ProtocolHandler
-from bokeh.server.views.static_handler import StaticHandler
-from bokeh.settings import settings
-from bokeh.util.token import (
-    check_token_signature,
-    generate_jwt_token,
-    generate_session_id,
-    get_session_id,
-    get_token_payload,
-)
-from tornado.ioloop import IOLoop
+from bokeh_fastapi import BokehFastAPI
+from bokeh_fastapi.handler import WSHandler 
+from panel.io.document import extra_socket_handlers
 
+def dispatch_fastapi(conn, events=None, msg=None):
+    if msg is None:
+        msg = conn.protocol.create('PATCH-DOC', events)
+    return [conn._socket.send_message(msg)]
 
-class DocRouter:
+extra_socket_handlers[WSHandler] = dispatch_fastapi
 
-    def __init__(self, prefix: str, application_contexts: list[ApplicationContext]):
-        self.application_contexts = application_contexts
+def panel_app(doc):
 
-        self._prefix = prefix
-        self.router = APIRouter()
-        for route, context in application_contexts.items():
-            self.router.add_api_route('/{app:path}', self.get, methods=['GET'])
-            self.router.add_websocket_route('/{app:path}/ws', self.ws_connect)
-            if context.io_loop is None:
-                context._loop = IOLoop.current()
+    from panel.io.state import set_curdoc
 
-    async def _get_session(self, app: str, request: Request, session_id: str | None) -> ServerSession:
-        if session_id is None:
-            session_id = generate_session_id(secret_key=None, signed=False)
-        payload = {
-            'headers': dict(request.headers),
-            'cookies': dict(request.cookies)
-        }
-        token = generate_jwt_token(
-            session_id,
-            secret_key=None,
-            signed=False,
-            expiration=300,
-            extra_payload=payload
-        )
-        request.protocol = 'http'
-        request.host = request.client.host
-        request.uri = request.url.path
-        session = await self.application_contexts[f'/{app}'].create_session_if_needed(
-            session_id, request, token
-        )
-        return session
+    doc.on_event('document_ready', partial(pn.state._schedule_on_load, doc))
 
-    def resources(self, absolute_url: str | None = None) -> Resources:
-        mode = settings.resources(default="server")
-        if mode == "server":
-            root_url = urljoin(absolute_url, self._prefix) if absolute_url else self._prefix
-            return Resources(mode="server", root_url=root_url, path_versioner=StaticHandler.append_version)
-        return Resources(mode=mode)
-
-    async def get(self, app: str, request: Request, bokeh_session_id: str | None = None) -> HTMLResponse:
-        if f'/{app}' not in self.application_contexts:
-            return
-        session = await self._get_session(app, request, bokeh_session_id)
-        page = server_html_page_for_session(
-            session,
-            resources=self.resources(),
-            title=session.document.title,
-            template=session.document.template,
-            template_variables=session.document.template_variables
-        )
-        return HTMLResponse(page)
-
-    async def ws_connect(self, websocket):
-        app = websocket.path_params['app']
-        if len(websocket.scope['subprotocols']) == 2:
-            subprotocol, token = websocket.scope['subprotocols']
-        else:
-            subprotocol = None
-        if subprotocol != 'bokeh' or token is None:
-            websocket.close()
-            raise RuntimeError("Subprotocol header is not 'bokeh' or token not provided")
-
-        now = calendar.timegm(dt.datetime.now(tz=dt.timezone.utc).timetuple())
-        payload = get_token_payload(token)
-        if 'session_expiry' not in payload:
-            websocket.close()
-            raise RuntimeError("Session expiry has not been provided")
-        elif now >= payload['session_expiry']:
-            websocket.close()
-            raise RuntimeError("Token is expired.")
-
-        await websocket.accept('bokeh')
-        self._websocket = websocket
-
-        context = self.application_contexts[f'/{app}']
-        
-        #log.debug("ProtocolHandler created for %r", protocol)
-
-        await websocket_handler(websocket, context, token)
-
-
-class SocketHandler:
-
-    def __init__(self, websocket: Websocket):
-        self._socket = websocket
-
-    async def send_text(self, text):
-        await self._socket.send_text(text)
-        
-    async def send_bytes(self, bytestream):
-        await self._socket.send_bytestream(bytestream)
-
-    async def send_message(self, message: Message) -> int:
-        sent = 0
-        try:
-            await self._socket.send_text(message.header_json)
-            sent += len(message.header_json)
-
-            await self._socket.send_text(message.metadata_json)
-            sent += len(message.metadata_json)
-
-            await self._socket.send_text(message.content_json)
-            sent += len(message.content_json)
-
-            for header, payload in message._buffers:
-                await self._socket.send_text(json.dumps(header))
-                await self._socket.send_bytes(payload)
-                sent += len(header) + len(payload)
-        except Exception as e:
-            print(e)
-        return sent
-
-        
-
-async def websocket_handler(socket: Websocket, application_context: ApplicationConext, token):
-    session_id = get_session_id(token)
-    await application_context.create_session_if_needed(session_id, socket.scope, token)
-    session = application_context.get_session(session_id)
-
-    ws_handler = SocketHandler(socket)
-    protocol = Protocol()
-    receiver = Receiver(protocol)
-    handler = ProtocolHandler()
-    connection = ServerConnection(protocol, ws_handler, application_context, session)
-
-    msg = connection.protocol.create('ACK')
-    await ws_handler.send_message(msg)
-
-    while True:
-        ws_msg = await socket.receive()
-
-        if 'text' in ws_msg:
-            fragment = ws_msg['text']
-        message = await receiver.consume(fragment)
-        if message:
-            work = await handler.handle(message, connection)
-            if work:
-                await ws_handler.send_message(work)
-        
-def _eval_panel(obj, doc: Document):
-    if isinstance(obj, (FunctionType, MethodType)):
-        obj = obj()
-        
     with set_curdoc(doc):
-        return as_panel(obj).server_doc(doc)
-   
-def add_application_routes(server, apps, prefix='/'):
-    contexts = {}
-    for url, app in apps.items():       
-        if isinstance(app, pathlib.Path):
-            app = str(app) # enables serving apps from Paths
-        if (isinstance(app, str) and app.endswith(('.py', '.ipynb', '.md'))
-            and os.path.isfile(app)):
-            app = build_single_handler_application(app)
-        elif not isinstance(app, Application):
-            handler = FunctionHandler(partial(_eval_panel, app))
-            app = Application(handler)
-        contexts[url] = app_context = ApplicationContext(app, url=url)
-    router = DocRouter(prefix=prefix, application_contexts=contexts)
+        slider = pn.widgets.IntSlider(start=0, end=10, value=5)
+        out = pn.Column(
+            pn.pane.Markdown('### ' + pn.rx('*') * slider),
+            pn.state.session_info,
+            pn.state.curdoc
+        )
+        tmpl = pn.template.MaterialTemplate(main=[slider, out], title='Hello World')
+        tmpl.server_doc(doc)
 
-    # Mount static file handlers
-    for ext_name, ext_path in extension_dirs.items():
-        server.mount(f"/static/extensions/{ext_name}", StaticFiles(directory=ext_path), name=ext_name)
-    server.mount("/static", StaticFiles(directory=settings.bokehjsdir()), name="static")
-        
-    # Mount application router
-    server.include_router(router.router)
+handler = FunctionHandler(panel_app)
+application = Application(handler)
 
-def create_server(apps):
-    server = FastAPI()
-    add_application_routes(server, apps)
-    return server
-
-def panel_app():
-    import panel as pn
-    slider = pn.widgets.IntSlider(start=0, end=10, value=5)
-    out = pn.pane.Markdown('### ' + pn.rx('*') * slider)
-    return pn.template.MaterialTemplate(main=[slider, out], title='Hello World')
-
-app = create_server({'/foo': panel_app})
+app = BokehFastAPI(app).server


### PR DESCRIPTION
This refactors the existing hacky implementation into something real which mirrors the architecture of Bokeh's default `BokehTornado` component and associated `DocHandler` and `WSHandler` including support for a variety of the configuration options. This is done with the aim to eventually support FastAPI as a drop-in replacement for the Tornado based server.

There's quite a few things left to do, off the top of my head this includes:

- [ ] Set up CI and a few tests
- [ ] Flesh out the README as stand-in for some basic documentation
- [ ] Add support for keep-alive pings and session cleanup
- [ ] Figure out what adding auth looks like
- [ ] Figure out how to handle `from panel.io.server import server_html_page_for_session` import

Eventually we'd also like to:

- [ ] Figure out if we can set everything up without import tornado at all (this likely requires work in Bokeh)