### PR TITLE
Create a WSHandler per session

### DIFF
--- a/src/bokeh_fastapi/application.py
+++ b/src/bokeh_fastapi/application.py
@@ -251,9 +251,9 @@ class BokehFastAPI:
         for route, ctx in self._applications.items():
             doc_handler = DocHandler(self, application_context=ctx)
             self.app.add_api_route(f"{route}", doc_handler.get, methods=["GET"])
-            ws_handler = WSHandler(self, application_context=ctx)
+            ws_handler = WSHandler.create_factory(self, application_context=ctx)
             route = route if route.endswith("/") else f"{route}/"
-            self.app.add_websocket_route(f"{route}ws", ws_handler.ws_connect)
+            self.app.add_websocket_route(f"{route}ws", ws_handler)
 
         # Mount static file handlers
         for ext_name, ext_path in extension_dirs.items():

--- a/src/bokeh_fastapi/handler.py
+++ b/src/bokeh_fastapi/handler.py
@@ -140,6 +140,13 @@ class WSHandler(SessionHandler):
         self.connection = None
         self._socket: WebSocket
 
+    @classmethod
+    def create_factory(cls, application: BokehFastAPI, application_context: ApplicationContext):
+        def create_handler(*args, **kwargs):
+            inst = cls(application, application_context)
+            return inst.ws_connect(*args, **kwargs)
+        return create_handler
+
     def check_origin(self, origin: str) -> bool:
         """Implement a check_origin policy for Tornado to call.
 


### PR DESCRIPTION
There was a pretty major oversight in the way `WSHandler` was handled. Specifically we instantiated a single instance of the handler which would then be overridden every time a new session was created. To solve this we add a factory method that creates a new `WSHandler` per session ensuring the receive/send loop runs independently for all sessions.