### PR TITLE
fix cookie handling in session creation

### DIFF
--- a/src/bokeh_fastapi/handler.py
+++ b/src/bokeh_fastapi/handler.py
@@ -63,7 +63,7 @@ class SessionHandler:
         )
 
         headers = dict(request.headers)
-        cookies = dict(request.cookies)
+        cookies = {name: cookie.value for name, cookie in request.cookies}
 
         if app.include_headers is None:
             excluded_headers = app.exclude_headers or []


### PR DESCRIPTION
I broke this in #13. `tornado.httputil.HTTPServerRequest.cookies` is not `dict[str, str]`, but rather `dict[str, http.cookies.Morsel]`. Thus we need to extract the value here before passing it on.