### PR TITLE
add websockets as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,10 @@ authors = [
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
+    "bokeh>=2.3.3",
     "fastapi>=0.68.0",
     "starlette",
-    "bokeh>=2.3.3",
+    "websockets>=10.4",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Without that installed, FastAPI cannot handle websocket connections. This is not an issue for `pip install panel[fastapi]`, because this internally {installs `fastapi[standard]`](https://github.com/holoviz/panel/blob/6e588b27479531bcff2af19ae27cca83d8a441d0/pyproject.toml#L79-L82), which ultimately also pulls in `websockets`. However this also pulls in more stuff that we don't need for this library.